### PR TITLE
Update gelf output plugin

### DIFF
--- a/templates/020-gelf.erb
+++ b/templates/020-gelf.erb
@@ -2,7 +2,6 @@ output {
 	gelf {
 		host => '<%= @graylog_server %>'
 		port => '<%= @port %>'
-		workers => 8
 		protocol => 'TCP'
 	}
 }


### PR DESCRIPTION
FIxes an error during startup:
```
Failed to execute action {
     :action=>LogStash::PipelineAction::Create/pipeline_id:main,
     :exception=>"LogStash::ConfigurationError",
     :message=>"You are using a plugin that doesn't support workers but have set the workers value explicitly! This plugin uses the legacy and doesn't need this option"
```