### PR TITLE
remove deprecated option

### DIFF
--- a/templates/jvm_options.erb
+++ b/templates/jvm_options.erb
@@ -17,7 +17,6 @@
 ################################################################
 
 ## GC configuration
--XX:+UseConcMarkSweepGC
 -XX:CMSInitiatingOccupancyFraction=75
 -XX:+UseCMSInitiatingOccupancyOnly
 


### PR DESCRIPTION
The following is logged when logstash is started:
OpenJDK 64-Bit Server VM warning: Option UseConcMarkSweepGC was deprecated in version 9.0 and will likely be removed in a future release.