### PR TITLE
Better internal logging

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -49,6 +49,15 @@ class ss_logstash::install inherits ss_logstash {
     notify  => Service['logstash'],
   }
 
+  file { '/etc/logstash/log4j2.properties':
+    ensure  => present,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    content => template('ss_logstash/log4j2.properties.erb'),
+    notify  => Service['logstash'],
+  }
+
   exec { 'install_lumberjack':
     command => '/usr/share/logstash/bin/logstash-plugin install logstash-input-lumberjack',
     timeout => 1800,

--- a/templates/log4j2.properties.erb
+++ b/templates/log4j2.properties.erb
@@ -1,0 +1,27 @@
+status = error
+name = LogstashPropertiesConfig
+
+# Only log to console, which will be picked up by systemd and then chucked into syslog
+appender.console.type = Console
+appender.console.name = plain_console
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = [%-5p][%-26c] %m%n
+
+rootLogger.level = ${sys:ls.log.level}
+rootLogger.appenderRef.console.ref = ${sys:ls.log.format}_console
+
+ # Slowlog
+
+# Only log to console, which will be picked up by systemd and then chucked into syslog
+appender.console_slowlog.type = Console
+appender.console_slowlog.name = plain_console_slowlog
+appender.console_slowlog.layout.type = PatternLayout
+appender.console_slowlog.layout.pattern = [%-5p][%-26c] %m%n
+
+logger.slowlog.name = slowlog
+logger.slowlog.level = trace
+logger.slowlog.appenderRef.console_slowlog.ref = ${sys:ls.log.format}_console_slowlog
+logger.slowlog.additivity = false
+
+logger.licensereader.name = logstash.licensechecker.licensereader
+logger.licensereader.level = error


### PR DESCRIPTION
Logstash default logging will log both to a file and to syslog due to the console logging that goes via systemd to syslog.

This log4js file simplifies this a lot by only logging to console and also removes the timestamp since it also duplicated

Before:
```
2019-07-30T11:47:08.664427+12:00 ip-10-2-133-150 logstash[11450]: [2019-07-30T11:47:08,664][INFO ][org.logstash.beats.Server] Starting server on port: 5044
```

After:
```
2019-07-30T14:22:27.926781+12:00 sif-virtualbox-ubuntu-bionic-logstash logstash[24234]: [INFO ][org.logstash.beats.Server ] Starting server on port: 5044
```