### PR TITLE
Allow clients to be idle for two minutes

### DIFF
--- a/templates/conf.d/inputs.erb
+++ b/templates/conf.d/inputs.erb
@@ -5,6 +5,7 @@ input {
 		ssl => true
 		ssl_certificate => "/etc/pki/tls/certs/logstash.crt"
 		ssl_key => "/etc/pki/tls/private/logstash.key"
+		client_inactivity_timeout => 120
 	}
 	lumberjack {
 		port => 5000


### PR DESCRIPTION
A lot of filebeat log complains are that the client couldnt send events is because the server regards the client as inactive and sends a RST package back when the client sends. This change will double the timeout from 60 to 120 seconds.