### PR TITLE
Partitioned S3 long term storage

### DIFF
--- a/templates/conf.d/s3.erb
+++ b/templates/conf.d/s3.erb
@@ -30,7 +30,7 @@ output {
 		codec => "line"
 		canned_acl => "private"
 		rotation_strategy => "time"
-		prefix => "%{+YYYY}/%{+MM}/%{+dd}"
+		prefix => "year=%{+YYYY}/month=%{+MM}/day=%{+dd}"
 	}
   <% else  %>
   # S3bucket output is not enabled due to empty bucket name


### PR DESCRIPTION
Required for AWS Athena processing without manual partition creation. Somewhat discussed this with John during Hackday.

Without this, we either need to manually create partitions in Athena every day (new folders in S3),
or we need to scan the entire data set for each query, which will become quite expensive over time ($5 per TB). For queries which are date limited, we can reduce these costs. For queries across all available date ranges, and filter by information within the log files (e.g. ips, processes), we still need to do a full scan. That's a slightly different topic, we could do some post-processing on those S3 files, or more processing in Graylog before sending. But those are optimisations separate from this pull request.

See https://aws.amazon.com/premiumsupport/knowledge-center/athena-empty-results/
See https://blog.skeddly.com/2016/12/automatic-partitioning-with-amazon-athena.html

In order to migrate existing log entries, use this Python3 script
https://gist.github.com/chillu/3707c248a6a4f3ff7530458ed44015c4

**CAUTION: This operates on production data. In order to minimise the impact of the script getting something wrong, I'd recommend backing up the existing data, e.g. a copy-paste into a `backup/` subfolder via the S3 UI. The script will only match files with year/month/date in the root folder.**

```
pip3 install boto3
# Dry run, outputs what it would do
aws-vault exec silverstripe -- python3 s3-partition-rename.py --bucket=ananke-logs-logstash-logbucket-kpyweqygsl0h --dry
# Run for realz
aws-vault exec silverstripe -- python3 s3-partition-rename.py --bucket=ananke-logs-logstash-logbucket-kpyweqygsl0h
```

Context https://docs.google.com/document/d/1e7NjEf0juWA1oXMR-GvkhB639tlgtORWbq3zoVZnQo8/edit#

Docs draft: https://silverstripe.atlassian.net/wiki/spaces/~ischommer/pages/816743272/Searching+Long-Term+Logs+in+S3+via+AWS+Athena+DRAFT